### PR TITLE
Swamy/08aug work

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,7 @@ cube-orchestrator/
 ## Current Implementation Status
 
 The project currently includes:
+
 - **Task Management**: Task and TaskEvent structures with states (Pending, Scheduled, Running, Completed, Failed)
 - **Docker Integration**: Dedicated Docker package with client abstraction for container management
 - **Worker Implementation**: Worker nodes with task queues, databases, and lifecycle management
@@ -80,6 +81,7 @@ The project currently includes:
 ## Architecture Evolution
 
 The project follows Go standard project layout:
+
 - `cmd/`: Application entry points and main packages
 - `internal/`: Private packages not intended for external use
 - `pkg/`: Public API packages (planned for future external consumption)
@@ -102,19 +104,29 @@ The project follows Go standard project layout:
 ## Coding Guidelines
 
 ### Go Standards
+
 - Follow standard Go conventions and idioms
 - Use `gofmt` for code formatting
 - Write clear, descriptive variable and function names
 - Include appropriate error handling
 - Add meaningful comments for complex logic
+- **File Headers**: Always include a file path comment at the top of Go files using the format:
+
+  ```go
+  // File: src/orchestrator/internal/package/filename.go
+
+  package packagename
+  ```
 
 ### Architecture Principles
+
 - Design for modularity and testability
 - Implement clear separation of concerns
 - Use interfaces to define contracts between components
 - Keep functions focused and single-purpose
 
 ### Orchestrator-Specific Patterns
+
 - Follow event-driven architecture where appropriate
 - Implement proper state management for tasks and workers (Pending, Scheduled, Running, Completed, Failed states)
 - Use goroutines and channels for concurrent operations
@@ -127,6 +139,7 @@ The project follows Go standard project layout:
 - Follow internal/ vs pkg/ package organization for API development
 
 ### Code Organization
+
 - Place private functionality in `internal/` packages
 - Reserve `pkg/` for future public APIs
 - Use descriptive package names that reflect their purpose
@@ -135,6 +148,7 @@ The project follows Go standard project layout:
 - Follow established patterns for Docker abstraction and container lifecycle management
 
 ### Documentation
+
 - Include package-level documentation
 - Document exported functions and types
 - Provide examples for complex APIs
@@ -156,6 +170,7 @@ The project follows Go standard project layout:
 ## Learning Focus Areas
 
 When suggesting code or improvements, consider these key learning objectives:
+
 - Understanding container runtime interfaces
 - Implementing scheduling algorithms based on resource availability
 - Managing cluster state and health monitoring

--- a/src/orchestrator/internal/node/node.go
+++ b/src/orchestrator/internal/node/node.go
@@ -1,4 +1,4 @@
-// File: src/node/node.go
+// File: src/orchestrator/internal/node/node.go
 
 package node
 

--- a/src/orchestrator/internal/runtime/client.go
+++ b/src/orchestrator/internal/runtime/client.go
@@ -1,3 +1,5 @@
+// File: src/orchestrator/internal/runtime/client.go
+
 package runtime
 
 import (

--- a/src/orchestrator/internal/scheduler/scheduler.go
+++ b/src/orchestrator/internal/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-// File: src/scheduler/scheduler.go
+// File: src/orchestrator/internal/scheduler/scheduler.go
 
 package scheduler
 

--- a/src/orchestrator/internal/task/state.go
+++ b/src/orchestrator/internal/task/state.go
@@ -1,3 +1,5 @@
+// File: src/orchestrator/internal/task/state.go
+
 package task
 
 // State represents the current state of a task in the orchestration lifecycle

--- a/src/orchestrator/internal/task/state_machine.go
+++ b/src/orchestrator/internal/task/state_machine.go
@@ -1,4 +1,4 @@
-// File: src/task/state_machine.go
+// File: src/orchestrator/internal/task/state_machine.go
 
 package task
 

--- a/src/orchestrator/internal/task/task.go
+++ b/src/orchestrator/internal/task/task.go
@@ -1,3 +1,5 @@
+// File: src/orchestrator/internal/task/task.go
+
 package task
 
 import (


### PR DESCRIPTION
This pull request improves project documentation and code organization standards for the orchestrator, with a focus on Go best practices and maintainability. The main changes include enhanced guidelines in `.github/copilot-instructions.md` and the addition or correction of file path headers in several Go source files.

**Documentation and Guidelines Updates**

* Expanded `.github/copilot-instructions.md` to clarify project architecture, Go coding standards, file header requirements, code organization, documentation expectations, and learning objectives. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R70) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R84) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R107-R129) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R142) [[5]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R151) [[6]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R173)

**Codebase Organization and Consistency**

* Added or corrected file path header comments at the top of Go files in `src/orchestrator/internal/node/node.go`, `src/orchestrator/internal/runtime/client.go`, `src/orchestrator/internal/scheduler/scheduler.go`, `src/orchestrator/internal/task/state.go`, `src/orchestrator/internal/task/state_machine.go`, and `src/orchestrator/internal/task/task.go` to comply with new documentation standards. [[1]](diffhunk://#diff-33dcf9aa22b46d577b2bf5aa4af598f3af4b4fd4074013745ac82565cc28431bL1-R1) [[2]](diffhunk://#diff-d0dcd3ca430704c8ada39a6b4d889361089f48c8e675b66329e3b48cae64ee20R1-R2) [[3]](diffhunk://#diff-74a58bbc3f4b4d1d17628cb2ba3f6c69c5e3b9bd4574a234682a6791d131c540L1-R1) [[4]](diffhunk://#diff-3d25b7c52bad8cdf0982f43962a2b52772c97af4bc00e1b3ee41e654fea5ac50R1-R2) [[5]](diffhunk://#diff-f839d6ef9a0daee93b87528679bde25ab01b09bd2cb2510a701d79520fbc8025L1-R1) [[6]](diffhunk://#diff-31973f1466dc6dac7a5535e8b4174c7121b143b33c90eca7012a182373c9060bR1-R2)