### PR TITLE
Add pre-push hook for automated documentation checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Lightweight pre-push docs guard
+# - Runs only when pushing to the 'main' branch
+# - Runs only if README.md or files under docs/ changed in the push range
+# - Respects SKIP_DOCS_LINT and SKIP_LINK_CHECK env flags
+
+set -euo pipefail
+
+# Respect skip flags
+if [[ "${SKIP_DOCS_LINT:-}" == "1" ]]; then
+  echo "[pre-push] SKIP_DOCS_LINT set; skipping markdown lint."
+  SKIP_LINT=1
+else
+  SKIP_LINT=0
+fi
+
+if [[ "${SKIP_LINK_CHECK:-}" == "1" ]]; then
+  echo "[pre-push] SKIP_LINK_CHECK set; skipping link check."
+  SKIP_LINK=1
+else
+  SKIP_LINK=0
+fi
+
+run_checks=false
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Only consider pushes to main
+  branch_name="${local_ref##refs/heads/}"
+  if [[ "$branch_name" != "main" ]]; then
+    continue
+  fi
+
+  # Determine files changed between remote and local
+  changed_files=""
+  if [[ "$remote_sha" =~ ^0+$ ]]; then
+    # No remote history (new branch) – compare against the root
+    # Fallback: use the full diff of local branch
+    changed_files=$(git diff --name-only "$(git hash-object -t tree /dev/null)" "$local_sha" || true)
+  else
+    changed_files=$(git diff --name-only "$remote_sha" "$local_sha" || true)
+  fi
+
+  if echo "$changed_files" | grep -E -i '^(README\.md|docs/)' >/dev/null 2>&1; then
+    run_checks=true
+  fi
+done
+
+# If no docs changed or not pushing main, exit quietly
+if [[ "$run_checks" != "true" ]]; then
+  exit 0
+fi
+
+echo "[pre-push] Docs changed on main. Running checks..."
+
+# Markdown lint (if not skipped)
+if [[ "$SKIP_LINT" -eq 0 ]]; then
+  if command -v npx >/dev/null 2>&1; then
+    echo "[pre-push] Running markdownlint-cli2..."
+    npx --yes markdownlint-cli2 "README.md" "docs/**/*.md"
+  else
+    echo "[pre-push] npx not found; skipping markdown lint."
+  fi
+fi
+
+# Link check with Lychee via Docker (if not skipped)
+if [[ "$SKIP_LINK" -eq 0 ]]; then
+  if command -v docker >/dev/null 2>&1; then
+    echo "[pre-push] Running Lychee link checker..."
+    docker run --rm -w /input -v "${PWD}:/input" lycheeverse/lychee:latest \
+      --config lychee.toml --no-progress README.md docs/**/*.md
+  else
+    echo "[pre-push] Docker not found; skipping link check."
+  fi
+fi
+
+echo "[pre-push] Done.

--- a/README.md
+++ b/README.md
@@ -148,14 +148,18 @@ docker run --rm -w /input -v "${PWD}:/input" lycheeverse/lychee:latest --config 
 docker run --rm -w /input -v "${PWD}:/input" lycheeverse/lychee:latest --config lychee.toml --no-progress README.md docs/**/*.md
 ```
 
-### Optional: pre-commit hook for docs checks
+### Optional: hooks for docs checks
 
-You can enable a Git pre-commit hook to run both checks automatically when committing changes to docs:
+Enable Git hooks in this repo (applies to both pre-commit and pre-push hooks):
 
 ```powershell
 # From repo root (one-time setup)
 git config core.hooksPath .githooks
 ```
+
+Pre-commit hook: runs on any commit that includes README/docs changes.
+
+Pre-push hook (lightweight, recommended): runs only when pushing to main and only if README/docs changed in the push range.
 
 Skip temporarily if needed:
 
@@ -165,4 +169,14 @@ $env:SKIP_DOCS_LINT = '1'; git commit -m "skip docs lint once"; Remove-Item Env:
 
 # Skip link check once
 $env:SKIP_LINK_CHECK = '1'; git commit -m "skip link check once"; Remove-Item Env:SKIP_LINK_CHECK
+```
+
+Skip on push instead (for the pre-push hook):
+
+```powershell
+# Skip markdown lint for the next push only
+$env:SKIP_DOCS_LINT = '1'; git push; Remove-Item Env:SKIP_DOCS_LINT
+
+# Skip link check for the next push only
+$env:SKIP_LINK_CHECK = '1'; git push; Remove-Item Env:SKIP_LINK_CHECK
 ```


### PR DESCRIPTION
This pull request introduces a lightweight pre-push Git hook to enforce documentation checks and updates the documentation to reflect this change. The new hook ensures that markdown linting and link checking are run only when pushing to the `main` branch and only if documentation files have changed, with options to skip these checks using environment variables. The `README.md` is updated to describe the new hook setup, its behavior, and how to temporarily skip checks.

**Documentation automation:**

* Added a `.githooks/pre-push` script that runs markdown lint and link checks when pushing to `main` if `README.md` or files under `docs/` have changed, with support for skip flags (`SKIP_DOCS_LINT`, `SKIP_LINK_CHECK`).

**README updates:**

* Clarified instructions for enabling Git hooks in the repository, distinguishing between pre-commit and the new pre-push hook, and explaining their respective behaviors.
* Added examples showing how to skip markdown lint or link checks for a single push using environment variables, specifically for the new pre-push hook.